### PR TITLE
Git honors alt_home

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
 
   # Ensure tests can sense settings about the environment
   TOX_OVERRIDE: >-
-    testenv.pass_env+=GITHUB_*,FORCE_COLOR
+    testenv.pass_env+=GITHUB_*,FORCE_COLOR,HOMEDRIVE,HOMEPATH
 
 
 jobs:

--- a/newsfragments/1.bugfix.rst
+++ b/newsfragments/1.bugfix.rst
@@ -1,0 +1,1 @@
+For better Git compatibility, suppress HOMEDRIVE and HOMEPATH vars.

--- a/pytest_home/fixtures.py
+++ b/pytest_home/fixtures.py
@@ -16,4 +16,7 @@ def alt_home(monkeypatch, tmp_path_factory):
     var = 'USERPROFILE' if platform.system() == 'Windows' else 'HOME'
     home = tmp_path_factory.mktemp('home')
     monkeypatch.setenv(var, str(home))
+    if platform.system() == 'Windows':
+        monkeypatch.delenv('HOMEDRIVE', raising=False)
+        monkeypatch.delenv('HOMEPATH', raising=False)
     return home

--- a/pytest_home/fixtures.py
+++ b/pytest_home/fixtures.py
@@ -16,7 +16,7 @@ def alt_home(monkeypatch, tmp_path_factory):
     var = 'USERPROFILE' if platform.system() == 'Windows' else 'HOME'
     home = tmp_path_factory.mktemp('home')
     monkeypatch.setenv(var, str(home))
-    if platform.system() == 'Windows':
+    if platform.system() == 'Windows':  # pragma: no cover
         monkeypatch.delenv('HOMEDRIVE', raising=False)
         monkeypatch.delenv('HOMEPATH', raising=False)
     return home

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,12 @@
+import subprocess
+
+
+def test_git_no_config(alt_home):
+    """
+    Ensure git finds config in alt_home.
+    """
+    alt_home.joinpath('.gitconfig').write_text(
+        '[user]\nemail="joe@pie.com"', encoding='utf-8'
+    )
+    out = subprocess.check_output(['git', 'config', 'user.email'])
+    out == 'joe@pie.com'


### PR DESCRIPTION
- Add test capturing expectation when git runs under alt_home.
- Have tox pass HOMEDRIVE+HOMEPATH to reveal the flaw.
- Remove legacy HOMEDRIVE and HOMEPATH variables on Windows if present. Closes #1.
